### PR TITLE
fix(extend)!: use a separate status code for when /extend fails

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -349,7 +349,7 @@ func (t *Timer) ExtendHandler(w http.ResponseWriter, r *http.Request) {
 	if cancelTimerHandle, ok := t.State.TimerMap[request.EventID]; !ok {
 		t.State.Unlock()
 
-		t.Logger.Error().Str("event_id", request.EventID).Msg("No evetn has been registered")
+		t.Logger.Error().Str("event_id", request.EventID).Msg("No event has been registered")
 		extendResponse, err := json.Marshal(&ExtendResponse{
 			EventID: request.EventID,
 			Message: fmt.Sprintf("No event with event_id %s has been registered", request.EventID),
@@ -363,7 +363,7 @@ func (t *Timer) ExtendHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.Header().Add("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusFailedDependency)
 		_, _ = w.Write(extendResponse)
 		return
 	} else {


### PR DESCRIPTION
When extend fails due to timer getting over, we can use a different status code so the bot can identify if it needs to create a new timer instead from extend. Paging @bwaklog to review.